### PR TITLE
unicode-identifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "sql-jsonpath-js",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sql-jsonpath-js",
   "version": "1.0.0",
   "description": "JS implementation of the SQL JSONPath dialect, from SQL2016.",
-  "main": "dist/index.ts",
+  "main": "dist/index.js",
   "scripts": {
     "test": "test",
     "start": "npx tsc && node ./dist/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,5 @@ function parseInput(text: string) {
     throw new Error(`sad sad panda, Parsing errors detected: ${parser.errors[0]}`)
   }
 }
-
-const inputText = "$.foo.bar"
+const inputText = "$._ಠ_ಠ.bar"
 parseInput(inputText)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -16,6 +16,7 @@ import {
   LteOperator,
   LtOperator,
   MethodEnd,
+  MethodName,
   MethodStart,
   NotEqualsOperator,
   NotEqualsOperator2,
@@ -52,7 +53,7 @@ export class JsonPathParser extends CstParser {
   })
 
   method = this.RULE("method", () => {
-    this.CONSUME(Identifier)
+    this.CONSUME(MethodName)
     this.CONSUME(MethodStart)
     this.SUBRULE(this.arguments)
     this.CONSUME(MethodEnd)

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,7 +2,7 @@ import {createToken, Lexer} from "chevrotain";
 
 export const Wildcard = createToken({name: "Wildcard", pattern: /\*/})
 
-export const Identifier = createToken({ name: "Identifier", pattern: /[a-zA-Z]\w*/ })
+export const Identifier = createToken({ name: "Identifier", pattern: /\w+/u })
 
 export const ObjectRoot = createToken({name: "Root", pattern: /\$/})
 
@@ -49,6 +49,8 @@ export const NotOperator = createToken({name: "NotOperator", pattern: /!/})
 export const True = createToken({name: "True", pattern: /true/})
 
 export const False = createToken({name: "False", pattern: /false/})
+
+export const MethodName = createToken({ name: "MethodName", pattern: /[a-zA-Z]\w*/ })
 
 export const MethodStart = createToken({name: "MethodStart", pattern: /\(/})
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,9 +2,10 @@ import {createToken, Lexer} from "chevrotain";
 
 export const Wildcard = createToken({name: "Wildcard", pattern: /\*/})
 
-export const Identifier = createToken({ name: "Identifier", pattern: /\w+/u })
-
+// define '$' before Identifier as ID character class includes '$'
 export const ObjectRoot = createToken({name: "Root", pattern: /\$/})
+
+export const Identifier = createToken({ name: "Identifier", pattern: /[\p{ID_Start}]\p{ID_Continue}*/u })
 
 export const FilterValue = createToken({name: "FilterValue", pattern: /@/})
 
@@ -50,7 +51,7 @@ export const True = createToken({name: "True", pattern: /true/})
 
 export const False = createToken({name: "False", pattern: /false/})
 
-export const MethodName = createToken({ name: "MethodName", pattern: /[a-zA-Z]\w*/ })
+export const MethodName = createToken({ name: "MethodName", pattern: /[a-zA-Z]+/ })
 
 export const MethodStart = createToken({name: "MethodStart", pattern: /\(/})
 


### PR DESCRIPTION
* JS object identifiers can be unicode values, including emoji. We will likely need to revisit identifiers when we work on expressions like `my😊["a key in my😊"]`
* Method names for json-path are all ascii, so created a new Token for MethodName.