### PR TITLE
Cleanup tasks

### DIFF
--- a/src/json-path.ts
+++ b/src/json-path.ts
@@ -18,12 +18,6 @@ export type PathQuery = PathPart[]
 export interface SqlJsonPathStatement {
   mode?: Mode
   lhs?: PathQuery | number
-  operation?: Operation
-}
-
-export interface Operation {
-  operator: SqlJsonPathArithmeticOperator
-  operand: PathQuery | number
 }
 
 export interface Method {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -20,7 +20,7 @@ import {
   NotEqualsOperator,
   NotEqualsOperator2,
   NotOperator,
-  ObjectRoot,
+  ContextItem,
   OrOperator,
   PathSeparator,
   RightSquareBracket,
@@ -41,11 +41,7 @@ export class JsonPathParser extends CstParser {
 
   jsonPathStatement = this.RULE("jsonPathStatement", () => {
     this.OPTION(() => this.SUBRULE(this.mode, { LABEL: "mode" }))
-    this.OPTION1(() => this.SUBRULE(this.operand, { LABEL: "lhs" }))
-    this.OPTION2(() => {
-      this.SUBRULE(this.arithmeticOperator, { LABEL: "operator" })
-      this.SUBRULE2(this.operand, { LABEL: "rhs" })
-    })
+    this.OPTION1(() => this.SUBRULE(this.contextQuery, { LABEL: "lhs" }))
   })
 
   mode = this.RULE("mode", () => {
@@ -53,16 +49,6 @@ export class JsonPathParser extends CstParser {
       this.OR([
         { ALT: () => this.CONSUME(Lax, { LABEL: "lax" }) },
         { ALT: () => this.CONSUME(Strict, { LABEL: "strict" }) }
-      ])
-    })
-  })
-
-
-  operand = this.RULE("operand", () => {
-    this.OPTION(() => {
-      this.OR([
-        { ALT: () => this.SUBRULE(this.rootQuery, { LABEL: "path" }) },
-        { ALT: () => this.CONSUME(Integer, { LABEL: "number" }) }
       ])
     })
   })
@@ -76,8 +62,8 @@ export class JsonPathParser extends CstParser {
     this.CONSUME(MethodEnd)
   })
 
-  rootQuery = this.RULE("rootQuery", () => {
-    this.CONSUME(ObjectRoot)
+  contextQuery = this.RULE("contextQuery", () => {
+    this.CONSUME(ContextItem)
     this.OPTION(() => {
       this.CONSUME(PathSeparator)
       this.SUBRULE(this.pathQuery, { LABEL: "path" })
@@ -146,10 +132,6 @@ export class JsonPathParser extends CstParser {
     ])
   })
 
-  arithmeticOperator = this.RULE("arithmeticOperator", () => {
-    this.CONSUME(ArithmeticOperator, { LABEL: "operator" })
-  })
-
   pathPart = this.RULE("pathPart", () => {
     this.CONSUME(Identifier, { LABEL: "name" })
     this.OPTION(() =>
@@ -188,7 +170,6 @@ export class JsonPathParser extends CstParser {
       this.SUBRULE(this.op, { LABEL: "ops" })
     })
   })
-
 
   arrayAccessor = this.RULE("arrayAccessor", () => {
     this.CONSUME(LeftSquareBracket)

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -2,8 +2,7 @@ import {createToken, Lexer} from "chevrotain";
 
 // Declaration order matters
 export const Wildcard               = createToken({name: "Wildcard", pattern: /\*/})
-// define '$' before Identifier as ID character class includes '$'
-export const ObjectRoot             = createToken({name: "Root", pattern: /\$/})
+export const ContextItem            = createToken({name: "ContextItem", pattern: /\$/})
 export const Lax                    = createToken({name: "Lax", pattern: /lax/})
 export const Strict                 = createToken({name: "Strict", pattern: /strict/})
 export const Identifier             = createToken({name: "Identifier", pattern: /[a-zA-Z]\w*/})
@@ -65,7 +64,7 @@ export const allTokens = [
   NotOperator,
   LeftSquareBracket,
   RightSquareBracket,
-  ObjectRoot,
+  ContextItem,
   PathSeparator,
   Comma,
   Wildcard,

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -1,4 +1,4 @@
-import { CstNode, ICstVisitor } from "@chevrotain/types"
+import {CstNode, ICstVisitor} from "@chevrotain/types"
 import {
   ArrayElement,
   ConditionalOperator,
@@ -12,10 +12,10 @@ import {
   PathPart,
   PathQuery,
   SimpleProperty,
-  SqlJsonPathArithmeticOperator,
   SqlJsonPathStatement,
   WFF
 } from "./json-path"
+
 
 export function newJsonPathVisitor(constr: { new(...args: any[]): ICstVisitor<any, any> }) {
   return new class JsonPathVisitor extends constr {
@@ -35,13 +35,6 @@ export function newJsonPathVisitor(constr: { new(...args: any[]): ICstVisitor<an
         obj.lhs = this.visit(ctx.lhs)
       }
 
-      if (ctx.rhs && ctx.operator) {
-        obj.operation = {
-          operator: this.visit(ctx.operator),
-          operand: this.visit(ctx.rhs)
-        }
-      }
-
       return obj
     }
 
@@ -49,12 +42,6 @@ export function newJsonPathVisitor(constr: { new(...args: any[]): ICstVisitor<an
       return ctx.strict
         ? "strict"
         : "lax"
-    }
-
-    operand(ctx: any): PathQuery | number {
-      return (ctx.path)
-        ? this.visit(ctx.path)
-        : ctx.number
     }
 
     arguments(ctx: any): string[] {
@@ -128,23 +115,6 @@ export function newJsonPathVisitor(constr: { new(...args: any[]): ICstVisitor<an
           return ConditionalOperator.NE
         default:
           throw Error("Unknown conditional operator: " + ctx.operator[0].image)
-      }
-    }
-
-    arithmeticOperator(ctx: any): SqlJsonPathArithmeticOperator {
-      switch (ctx.operator) {
-        case "+":
-          return SqlJsonPathArithmeticOperator.ADD
-        case "-":
-          return SqlJsonPathArithmeticOperator.SUB
-        case "*":
-          return SqlJsonPathArithmeticOperator.MUL
-        case "/":
-          return SqlJsonPathArithmeticOperator.DIV
-        case "%":
-          return SqlJsonPathArithmeticOperator.MOD
-        default:
-          throw new Error("Unknown operator type: " + ctx.operator)
       }
     }
 

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -63,7 +63,7 @@ export function newJsonPathVisitor(constr: { new(...args: any[]): ICstVisitor<an
         : []
     }
 
-    rootQuery(ctx: any): PathQuery {
+    contextQuery(ctx: any): PathQuery {
       return this.visit(ctx.path)
     }
 


### PR DESCRIPTION
- Renamed 'root' to 'context' as the spec calls the thing '$' refers to as the context item.
- Tightened up sqlJsonPath to only allow mode or contextQuery as per the spec.
- Remove unused 'operand', 'arithmeticOperator' rules.